### PR TITLE
Hide unused UAD plugins from showing up in your DAW

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Audio Production Scripts
 helper scripts and tools for audio production
+
+## Uninstallers
+- Native Instrument Guitar Rig 5 / 6 / 7
+
+## Tools
+- Uad Cleanup Tool (Hide unused UAD plugins from logic) 


### PR DESCRIPTION
- shell script that hides unpurchased UAD plugins, stopping them from showing up in Logic Pro X
- (more DAW's and OS's to come?)